### PR TITLE
Adding Docker container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.10-alpine
+
+RUN apk add --update make git zip
+
+ENV GOPATH /usr/local/go
+
+RUN mkdir -p ${GOPATH}/src/github.com/inovex/ && \
+    git clone https://github.com/inovex/mqtt-stresser.git ${GOPATH}/src/github.com/inovex/mqtt-stresser/
+
+RUN cd ${GOPATH}/src/github.com/inovex/mqtt-stresser/ && \
+    make
+
+RUN cd ${GOPATH}/src/github.com/inovex/mqtt-stresser/build && \
+    tar -xzvf mqtt-stresser-linux-amd64.tar.gz && \
+    cp mqtt-stresser /bin
+
+ENTRYPOINT [ "/bin/mqtt-stresser" ]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ This will build the mqtt stresser for all target platforms and write them to the
 
 Binaries are provided on Github, see https://github.com/inovex/mqtt-stresser.
 
+If you want to build the Docker container version of this, go to repository directory and simply type ``docker build .``
+
 ## Install
 
 Place the binary somewhere in a ``PATH`` directory and make it executable (``chmod +x mqtt-stresser``).
+
+If you are using the container version, just type ``docker run flaviostutz/mqtt-stresser [options]`` for running mqtt-stresser.
 
 ## Configure
 
@@ -81,4 +85,9 @@ Median: 293 msg/sec
   < 217 msg/sec  8%
   < 171 msg/sec  2%
   < 79 msg/sec  1%
+```
+
+If using container, 
+```
+$ docker run flaviostutz/mqtt-stresser -broker tcp://broker.mqttdashboard.com:1883 -num-clients 100 -num-messages 10 -rampup-delay 1s -rampup-size 10 -global-timeout 180s -timeout 20s
 ```


### PR DESCRIPTION
With Docker container support it maybe easier to build without the need to prepare the developer machines with proper tools, and you can run mqtt-tester directly from the container.