### PR TITLE
Print proper cumulative histograms

### DIFF
--- a/report.go
+++ b/report.go
@@ -186,20 +186,37 @@ func buildHistogram(series []float64, total int) map[float64]float64 {
 		keys = append(keys, k)
 	}
 
-	sort.Sort(sort.Reverse(sort.Float64Slice(keys)))
+	sort.Sort(sort.Float64Slice(keys))
 	histogram := make(map[float64]float64)
 
+	prev := 0.0
 	for _, k := range keys {
-		histogram[k] = float64(bucketCount[k]) / float64(total)
+		cur := float64(bucketCount[k])/float64(total) + prev
+		histogram[k] = cur
+		prev = cur
 	}
 
 	return histogram
 }
 
 func printHistogram(histogram map[float64]float64) {
-	for k, v := range histogram {
-		fmt.Printf("  < %.0f msg/sec  %.0f%%\n", k, v*100)
+
+	type histEntry struct {
+		key   float64
+		value float64
 	}
+
+	var res []histEntry
+	for k, v := range histogram {
+		res = append(res, histEntry{key: k, value: v})
+	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].key < res[j].key
+	})
+	for _, r := range res {
+		fmt.Printf("  < %.0f msg/sec  %.0f%%\n", r.key, r.value*100)
+	}
+
 }
 
 func median(series []float64) float64 {


### PR DESCRIPTION
New Output:
```
# Publishing Throughput
Fastest: 79852 msg/sec
Slowest: 6895 msg/sec
Median: 39060 msg/sec

  < 14191 msg/sec  3%
  < 21487 msg/sec  9%
  < 28783 msg/sec  14%
  < 36078 msg/sec  35%
  < 43374 msg/sec  63%
  < 50670 msg/sec  87%
  < 57965 msg/sec  96%
  < 65261 msg/sec  98%
  < 72557 msg/sec  99%
  < 87148 msg/sec  100%

# Receiving Througput
Fastest: 823 msg/sec
Slowest: 15 msg/sec
Median: 561 msg/sec

  < 95 msg/sec  4%
  < 176 msg/sec  11%
  < 257 msg/sec  16%
  < 338 msg/sec  20%
  < 419 msg/sec  25%
  < 500 msg/sec  33%
  < 580 msg/sec  58%
  < 661 msg/sec  82%
  < 742 msg/sec  97%
  < 823 msg/sec  99%
  < 904 msg/sec  100%
```