### PR TITLE
Simply return a new TLSConfig with just InsecureSkipVerify=true in ca…

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -45,6 +45,9 @@ type Worker struct {
 
 func setSkipTLS(o *mqtt.ClientOptions) {
 	oldTLSCfg := o.TLSConfig
+	if oldTLSCfg == nil {
+		oldTLSCfg = &tls.Config{}
+	}
 	oldTLSCfg.InsecureSkipVerify = true
 	o.SetTLSConfig(oldTLSCfg)
 }


### PR DESCRIPTION
In case there are no TLS specific options set on the command line the TLSConfig struct is nil an causes an NPE if i.e. only `-skip-tls-verification` is used to ignore the server certificate of a broker.