### PR TITLE
Don't exit if the unsubscribe failed. Only print the error message.

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -158,7 +158,7 @@ func (w *Worker) Run(ctx context.Context) {
 		verboseLogger.Printf("[%d] unsubscribe\n", w.WorkerId)
 
 		if token := subscriber.Unsubscribe(topicName); token.WaitTimeout(w.Timeout) && token.Error() != nil {
-			fmt.Printf("failed to unsubscribe: %v ", token.Error())
+			fmt.Printf("failed to unsubscribe: %v\n", token.Error())
 		}
 
 		subscriber.Disconnect(5)

--- a/worker.go
+++ b/worker.go
@@ -158,8 +158,7 @@ func (w *Worker) Run(ctx context.Context) {
 		verboseLogger.Printf("[%d] unsubscribe\n", w.WorkerId)
 
 		if token := subscriber.Unsubscribe(topicName); token.WaitTimeout(w.Timeout) && token.Error() != nil {
-			fmt.Println(token.Error())
-			os.Exit(1)
+			fmt.Printf("failed to unsubscribe: %v ", token.Error())
 		}
 
 		subscriber.Disconnect(5)


### PR DESCRIPTION
Fix #43 