### PR TITLE
avoid -skip-tls-verification override when providing certificates

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -105,15 +105,7 @@ func (w *Worker) Run(ctx context.Context) {
 
 	publisherOptions := mqtt.NewClientOptions().SetClientID(publisherClientId).SetUsername(w.Username).SetPassword(w.Password).AddBroker(w.BrokerUrl)
 
-	if w.SkipTLSVerification {
-		setSkipTLS(publisherOptions)
-	}
-
 	subscriberOptions := mqtt.NewClientOptions().SetClientID(subscriberClientId).SetUsername(w.Username).SetPassword(w.Password).AddBroker(w.BrokerUrl)
-
-	if w.SkipTLSVerification {
-		setSkipTLS(subscriberOptions)
-	}
 
 	subscriberOptions.SetDefaultPublishHandler(func(client mqtt.Client, msg mqtt.Message) {
 		queue <- [2]string{msg.Topic(), string(msg.Payload())}
@@ -126,6 +118,11 @@ func (w *Worker) Run(ctx context.Context) {
 		}
 		subscriberOptions.SetTLSConfig(tlsConfig)
 		publisherOptions.SetTLSConfig(tlsConfig)
+	}
+
+	if w.SkipTLSVerification {
+		setSkipTLS(publisherOptions)
+		setSkipTLS(subscriberOptions)
 	}
 
 	subscriber := mqtt.NewClient(subscriberOptions)


### PR DESCRIPTION
When using my self-signed certificates to connect to my broker, I noticed that the -skip-tls-verification flag was being overridden by the certificates initialization. Relocating the setSkipTLS after the certificates initialization fixes the problem.
