### PR TITLE
For your consideration: pub only, custom topic path, and load constant payload from file

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/pprof"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -51,6 +52,7 @@ var (
 	argCert                 = flag.String("cert", "", "client certificate for authentication, if required by server.")
 	argPauseBetweenMessages = flag.String("pause-between-messages", "0s", "Adds a pause between sending messages to simulate sensors sending messages infrequently")
 	argPubOnly              = flag.Bool("pub-only", false, "just publish, skip the subscriber process")
+	argTopicBasePath		= flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
 )
 
 type Result struct {
@@ -175,6 +177,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(*argTopicBasePath) > 0 {
+		topicNameTemplate = strings.Replace(topicNameTemplate, "internal/mqtt-stresser", *argTopicBasePath, 1)
+	}
+	
 	payloadGenerator := defaultPayloadGen()
 	if len(*argConstantPayload) > 0 {
 		verboseLogger.Printf("Set constant payload to %s\n", *argConstantPayload)

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	argKey                  = flag.String("key", "", "client private key for authentication, if required by server.")
 	argCert                 = flag.String("cert", "", "client certificate for authentication, if required by server.")
 	argPauseBetweenMessages = flag.String("pause-between-messages", "0s", "Adds a pause between sending messages to simulate sensors sending messages infrequently")
+	argPubOnly              = flag.Bool("pub-only", false, "just publish, skip the subscriber process")
 )
 
 type Result struct {
@@ -273,6 +274,7 @@ func main() {
 			Cert:                 cert,
 			Key:                  key,
 			PauseBetweenMessages: pauseBetweenMessages,
+			PubSub: 			  !*argPubOnly,
 		}).Run(testCtx)
 	}
 	fmt.Printf("%d worker started\n", *argNumClients)

--- a/main.go
+++ b/main.go
@@ -180,11 +180,22 @@ func main() {
 	if len(*argTopicBasePath) > 0 {
 		topicNameTemplate = strings.Replace(topicNameTemplate, "internal/mqtt-stresser", *argTopicBasePath, 1)
 	}
-	
+
 	payloadGenerator := defaultPayloadGen()
 	if len(*argConstantPayload) > 0 {
-		verboseLogger.Printf("Set constant payload to %s\n", *argConstantPayload)
-		payloadGenerator = constantPayloadGenerator(*argConstantPayload)
+		if strings.Index(*argConstantPayload, "@") == 0 {
+			inputPath := strings.Replace(*argConstantPayload, "@", "", 1)
+			content, err := ioutil.ReadFile(inputPath)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			verboseLogger.Printf("Set constant payload from file %s\n", *argConstantPayload)
+			payloadGenerator = constantPayloadGenerator(string(content))
+		} else {
+			verboseLogger.Printf("Set constant payload to %s\n", *argConstantPayload)
+			payloadGenerator = constantPayloadGenerator(*argConstantPayload)
+		}
 	}
 
 	var publisherQoS, subscriberQoS byte

--- a/worker.go
+++ b/worker.go
@@ -41,6 +41,7 @@ type Worker struct {
 	Cert                 []byte
 	Key                  []byte
 	PauseBetweenMessages time.Duration
+	PubSub				 bool
 }
 
 func setSkipTLS(o *mqtt.ClientOptions) {
@@ -107,9 +108,11 @@ func (w *Worker) Run(ctx context.Context) {
 
 	subscriberOptions := mqtt.NewClientOptions().SetClientID(subscriberClientId).SetUsername(w.Username).SetPassword(w.Password).AddBroker(w.BrokerUrl)
 
-	subscriberOptions.SetDefaultPublishHandler(func(client mqtt.Client, msg mqtt.Message) {
-		queue <- [2]string{msg.Topic(), string(msg.Payload())}
-	})
+	if w.PubSub {
+		subscriberOptions.SetDefaultPublishHandler(func(client mqtt.Client, msg mqtt.Message) {
+			queue <- [2]string{msg.Topic(), string(msg.Payload())}
+		})
+	}
 
 	if len(w.CA) > 0 || len(w.Key) > 0 {
 		tlsConfig, err := NewTLSConfig(w.CA, w.Cert, w.Key)
@@ -125,42 +128,44 @@ func (w *Worker) Run(ctx context.Context) {
 		setSkipTLS(subscriberOptions)
 	}
 
-	subscriber := mqtt.NewClient(subscriberOptions)
+	if w.PubSub {
+		subscriber := mqtt.NewClient(subscriberOptions)
 
-	verboseLogger.Printf("[%d] connecting subscriber\n", w.WorkerId)
-	if token := subscriber.Connect(); token.WaitTimeout(w.Timeout) && token.Error() != nil {
-		resultChan <- Result{
-			WorkerId:     w.WorkerId,
-			Event:        ConnectFailedEvent,
-			Error:        true,
-			ErrorMessage: token.Error(),
+		verboseLogger.Printf("[%d] connecting subscriber\n", w.WorkerId)
+		if token := subscriber.Connect(); token.WaitTimeout(w.Timeout) && token.Error() != nil {
+			resultChan <- Result{
+				WorkerId:     w.WorkerId,
+				Event:        ConnectFailedEvent,
+				Error:        true,
+				ErrorMessage: token.Error(),
+			}
+
+			return
 		}
 
-		return
+
+		defer func() {
+			verboseLogger.Printf("[%d] unsubscribe\n", w.WorkerId)
+
+			if token := subscriber.Unsubscribe(topicName); token.WaitTimeout(w.Timeout) && token.Error() != nil {
+				fmt.Printf("failed to unsubscribe: %v\n", token.Error())
+			}
+
+			subscriber.Disconnect(5)
+		}()
+
+		verboseLogger.Printf("[%d] subscribing to topic\n", w.WorkerId)
+		if token := subscriber.Subscribe(topicName, w.SubscriberQoS, nil); token.WaitTimeout(w.Timeout) && token.Error() != nil {
+			resultChan <- Result{
+				WorkerId:     w.WorkerId,
+				Event:        SubscribeFailedEvent,
+				Error:        true,
+				ErrorMessage: token.Error(),
+			}
+
+			return
+		}
 	}
-
-	defer func() {
-		verboseLogger.Printf("[%d] unsubscribe\n", w.WorkerId)
-
-		if token := subscriber.Unsubscribe(topicName); token.WaitTimeout(w.Timeout) && token.Error() != nil {
-			fmt.Printf("failed to unsubscribe: %v\n", token.Error())
-		}
-
-		subscriber.Disconnect(5)
-	}()
-
-	verboseLogger.Printf("[%d] subscribing to topic\n", w.WorkerId)
-	if token := subscriber.Subscribe(topicName, w.SubscriberQoS, nil); token.WaitTimeout(w.Timeout) && token.Error() != nil {
-		resultChan <- Result{
-			WorkerId:     w.WorkerId,
-			Event:        SubscribeFailedEvent,
-			Error:        true,
-			ErrorMessage: token.Error(),
-		}
-
-		return
-	}
-
 	publisher := mqtt.NewClient(publisherOptions)
 	verboseLogger.Printf("[%d] connecting publisher\n", w.WorkerId)
 	if token := publisher.Connect(); token.WaitTimeout(w.Timeout) && token.Error() != nil {
@@ -191,57 +196,66 @@ func (w *Worker) Run(ctx context.Context) {
 
 	publishTime := time.Since(t0)
 	verboseLogger.Printf("[%d] all messages published\n", w.WorkerId)
+	if w.PubSub {
+		t0 = time.Now()
+		for receivedCount < w.NumberOfMessages && !stopWorker {
+			select {
+			case <-queue:
+				receivedCount++
 
-	t0 = time.Now()
-	for receivedCount < w.NumberOfMessages && !stopWorker {
-		select {
-		case <-queue:
-			receivedCount++
-
-			verboseLogger.Printf("[%d] %d/%d received\n", w.WorkerId, receivedCount, w.NumberOfMessages)
-			if receivedCount == w.NumberOfMessages {
+				verboseLogger.Printf("[%d] %d/%d received\n", w.WorkerId, receivedCount, w.NumberOfMessages)
+				if receivedCount == w.NumberOfMessages {
+					resultChan <- Result{
+						WorkerId:          w.WorkerId,
+						Event:             CompletedEvent,
+						PublishTime:       publishTime,
+						ReceiveTime:       time.Since(t0),
+						MessagesReceived:  receivedCount,
+						MessagesPublished: publishedCount,
+					}
+				} else {
+					resultChan <- Result{
+						WorkerId:          w.WorkerId,
+						Event:             ProgressReportEvent,
+						PublishTime:       publishTime,
+						ReceiveTime:       time.Since(t0),
+						MessagesReceived:  receivedCount,
+						MessagesPublished: publishedCount,
+					}
+				}
+			case <-ctx.Done():
+				var event string
+				var isError bool
+				switch ctx.Err().(type) {
+				case TimeoutError:
+					verboseLogger.Printf("[%d] received abort signal due to test timeout", w.WorkerId)
+					event = TimeoutExceededEvent
+					isError = true
+				default:
+					verboseLogger.Printf("[%d] received abort signal", w.WorkerId)
+					event = AbortedEvent
+					isError = false
+				}
+				stopWorker = true
 				resultChan <- Result{
 					WorkerId:          w.WorkerId,
-					Event:             CompletedEvent,
+					Event:             event,
 					PublishTime:       publishTime,
-					ReceiveTime:       time.Since(t0),
 					MessagesReceived:  receivedCount,
 					MessagesPublished: publishedCount,
+					Error:             isError,
 				}
-			} else {
-				resultChan <- Result{
-					WorkerId:          w.WorkerId,
-					Event:             ProgressReportEvent,
-					PublishTime:       publishTime,
-					ReceiveTime:       time.Since(t0),
-					MessagesReceived:  receivedCount,
-					MessagesPublished: publishedCount,
-				}
-			}
-		case <-ctx.Done():
-			var event string
-			var isError bool
-			switch ctx.Err().(type) {
-			case TimeoutError:
-				verboseLogger.Printf("[%d] received abort signal due to test timeout", w.WorkerId)
-				event = TimeoutExceededEvent
-				isError = true
-			default:
-				verboseLogger.Printf("[%d] received abort signal", w.WorkerId)
-				event = AbortedEvent
-				isError = false
-			}
-			stopWorker = true
-			resultChan <- Result{
-				WorkerId:          w.WorkerId,
-				Event:             event,
-				PublishTime:       publishTime,
-				MessagesReceived:  receivedCount,
-				MessagesPublished: publishedCount,
-				Error:             isError,
 			}
 		}
+	}else{
+		resultChan <- Result{
+			WorkerId:          w.WorkerId,
+			Event:             CompletedEvent,
+			PublishTime:       publishTime,
+			ReceiveTime:       time.Since(t0),
+			MessagesReceived:  receivedCount,
+			MessagesPublished: publishedCount,
+		}
 	}
-
 	verboseLogger.Printf("[%d] worker finished\n", w.WorkerId)
 }


### PR DESCRIPTION
Hello:
I send this for you consideration. This changes have been very useful for our tests and maybe you can find some value in them too. There are 3 commits:

1.  setup a pub-only mode to skip the receiving part of the test cycle. I've been using this to help me pump data as fast as possible into my system. I wanted to disable the reception part because I'm measuring the performance of my own consumer against the broker, in isolation. 
2. set a custom topic path. This helps me activate my message routing during the load test. I just needed to set a base topic and let mqtt-stresser do the rest.
3. load the constant payload from a file. Following a convention I've seen in other tools, if the constant path string starts with "@" assume it's a file and load the payload from it. 

Like I said, these changes are useful in our usecase. It could be that this is not the best way to implement them (I'm open to ideas) but if you find any of this interesting let me know, I can send individual PRs if necessary.

I keep having fun with this tool, great work guys!
