### PR TITLE
Show worker progress

### DIFF
--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func main() {
 			}
 
 			if !*argHideProgress {
-				if msg.Event == CompletedEvent {
+				if msg.Event == ProgressReportEvent {
 					fmt.Print(".")
 				}
 


### PR DESCRIPTION
Hello,
I'm not sure if this is intentional, but the progress markers were being printed only when the worker has completed. 
I believe it is useful to show the progress of the worker with more detail. The change is very simple.

