### PR TITLE
Feature/allow random size payload generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 appname := mqtt-stresser
-namespace := inovex
+namespace = ${IMG_NAMESPACE}
+namespace ?= inovex
 sources := vendor $(wildcard *.go)
 
 build = GO111MODULE=on GOOS=$(1) GOARCH=$(2) go build -mod=vendor -o build/$(appname)-$(1)-$(2)$(3)

--- a/main.go
+++ b/main.go
@@ -51,7 +51,9 @@ var (
 	argKey                  = flag.String("key", "", "client private key for authentication, if required by server.")
 	argCert                 = flag.String("cert", "", "client certificate for authentication, if required by server.")
 	argPauseBetweenMessages = flag.String("pause-between-messages", "0s", "Adds a pause between sending messages to simulate sensors sending messages infrequently")
-	argTopicBasePath		= flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
+	argTopicBasePath        = flag.String("topic-base-path", "", "topic base path, if empty the default is internal/mqtt-stresser")
+	argMinMessageChars      = flag.Int("min-msg-chars", 0, "Minimum number of characters in message payload")
+	argMaxMessageChars      = flag.Int("max-msg-chars", 0, "Maximum number of characters in message payload")
 )
 
 type Result struct {
@@ -181,11 +183,16 @@ func main() {
 	}
 
 	payloadGenerator := defaultPayloadGen()
+	minChars := *argMinMessageChars
+	maxChars := *argMaxMessageChars
+	if minChars > 0 && maxChars > 0 && minChars < maxChars {
+		payloadGenerator = randomMessageGenerator(minChars, maxChars)
+	}
 	if len(*argConstantPayload) > 0 {
 		if strings.HasPrefix(*argConstantPayload, "@") {
 			verboseLogger.Printf("Set constant payload from file %s\n", *argConstantPayload)
 			payloadGenerator = filePayloadGenerator(*argConstantPayload)
-		}else {
+		} else {
 			verboseLogger.Printf("Set constant payload to %s\n", *argConstantPayload)
 			payloadGenerator = constantPayloadGenerator(*argConstantPayload)
 		}

--- a/worker.go
+++ b/worker.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -19,6 +20,24 @@ func defaultPayloadGen() PayloadGenerator {
 	return func(i int) string {
 		return fmt.Sprintf("this is msg #%d!", i)
 	}
+}
+
+func randomMessageGenerator(min, max int) PayloadGenerator {
+	rand.Seed(time.Now().UnixNano())
+	maxPayload := generateMaxPayload(max)
+	return func(i int) string {
+		size := rand.Intn(max-min+1) + min
+		return maxPayload[:size]
+	}
+}
+
+func generateMaxPayload(size int) string {
+	chars := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	buffer := make([]rune, size)
+	for i := range buffer {
+		buffer[i] = chars[i%len(chars)]
+	}
+	return string(buffer)
 }
 
 func constantPayloadGenerator(payload string) PayloadGenerator {


### PR DESCRIPTION
we have the requirement of generating messages with varying sizes throughout a load-test run given min and max limits. This change adds the ability to specify that via two new command line args.