### PR TITLE
feature/await all subscriptions before publishing

### DIFF
--- a/report.go
+++ b/report.go
@@ -13,6 +13,8 @@ const (
 	AbortedEvent         = "Aborted"
 	CompletedEvent       = "Completed"
 	ProgressReportEvent  = "ProgressReport"
+	SubscribedEvent      = "Subscribed"
+	StartPublishingEvent = "StartPublishing"
 )
 
 type Summary struct {

--- a/worker.go
+++ b/worker.go
@@ -174,6 +174,13 @@ func (w *Worker) Run(ctx context.Context) {
 
 		return
 	}
+	resultChan <- Result{
+		WorkerId: w.WorkerId,
+		Event:    SubscribedEvent,
+	}
+
+	for <-ctlChan != StartPublishingEvent {
+	}
 
 	publisher := mqtt.NewClient(publisherOptions)
 	verboseLogger.Printf("[%d] connecting publisher\n", w.WorkerId)


### PR DESCRIPTION
We wanted to only start sending messages when all clients successfully subscribed to their topics. Setting the flag -await-clients does that. 
When all workers issued a SubscribedEvent they in turn receive the command (StartPublishingEvent) to start publishing.